### PR TITLE
Add type inference

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,6 +9,12 @@
     "plugin:@typescript-eslint/recommended"
   ],
   "rules": {
-    "eol-last": "error"
+    "eol-last": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "varsIgnorePattern": "^_"
+      }
+    ]
   }
 }

--- a/src/BorshSchema.ts
+++ b/src/BorshSchema.ts
@@ -1,15 +1,15 @@
 import { Schema } from 'borsh';
-import { EnumType, StructType } from 'borsh/lib/types/types';
+import { BoolType, EnumType, MapType, OptionType, SetType, StringType, StructType } from 'borsh/lib/types/types';
 
-export class BorshSchema {
+export class BorshSchema<_S extends BSE> {
   private readonly schema: Schema;
 
   private constructor(schema: Schema) {
     this.schema = schema;
   }
 
-  static fromSchema(schema: Schema): BorshSchema {
-    return new BorshSchema(schema);
+  static fromSchema<S extends BSE>(schema: S): BorshSchema<S> {
+    return new BorshSchema<S>(schema);
   }
 
   toSchema(): Schema {
@@ -22,7 +22,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.u8, n);
    */
-  static get u8(): BorshSchema {
+  static get u8(): BorshSchema<U8> {
     return BorshSchema.fromSchema('u8');
   }
 
@@ -32,7 +32,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.u16, n);
    */
-  static get u16(): BorshSchema {
+  static get u16(): BorshSchema<U16> {
     return BorshSchema.fromSchema('u16');
   }
 
@@ -42,7 +42,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.u32, n);
    */
-  static get u32(): BorshSchema {
+  static get u32(): BorshSchema<U32> {
     return BorshSchema.fromSchema('u32');
   }
 
@@ -52,7 +52,7 @@ export class BorshSchema {
    * const n: bigint = 100n;
    * const buffer = borshSerialize(BorshSchema.u64, n);
    */
-  static get u64(): BorshSchema {
+  static get u64(): BorshSchema<U64> {
     return BorshSchema.fromSchema('u64');
   }
 
@@ -62,7 +62,7 @@ export class BorshSchema {
    * const n: bigint = 100n;
    * const buffer = borshSerialize(BorshSchema.u128, n);
    */
-  static get u128(): BorshSchema {
+  static get u128(): BorshSchema<U128> {
     return BorshSchema.fromSchema('u128');
   }
 
@@ -72,7 +72,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.i8, n);
    */
-  static get i8(): BorshSchema {
+  static get i8(): BorshSchema<I8> {
     return BorshSchema.fromSchema('i8');
   }
 
@@ -82,7 +82,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.i16, n);
    */
-  static get i16(): BorshSchema {
+  static get i16(): BorshSchema<I16> {
     return BorshSchema.fromSchema('i16');
   }
 
@@ -92,7 +92,7 @@ export class BorshSchema {
    * const n: number = 100;
    * const buffer = borshSerialize(BorshSchema.i32, n);
    */
-  static get i32(): BorshSchema {
+  static get i32(): BorshSchema<I32> {
     return BorshSchema.fromSchema('i32');
   }
 
@@ -102,7 +102,7 @@ export class BorshSchema {
    * const n: bigint = 100n;
    * const buffer = borshSerialize(BorshSchema.i64, n);
    */
-  static get i64(): BorshSchema {
+  static get i64(): BorshSchema<I64> {
     return BorshSchema.fromSchema('i64');
   }
 
@@ -112,7 +112,7 @@ export class BorshSchema {
    * const n: bigint = 100n;
    * const buffer = borshSerialize(BorshSchema.i128, n);
    */
-  static get i128(): BorshSchema {
+  static get i128(): BorshSchema<I128> {
     return BorshSchema.fromSchema('i128');
   }
 
@@ -122,7 +122,7 @@ export class BorshSchema {
    * const n: number = 1.0;
    * const buffer = borshSerialize(BorshSchema.f32, n);
    */
-  static get f32(): BorshSchema {
+  static get f32(): BorshSchema<F32> {
     return BorshSchema.fromSchema('f32');
   }
 
@@ -132,7 +132,7 @@ export class BorshSchema {
    * const n: number = 1.0;
    * const buffer = borshSerialize(BorshSchema.f64, n);
    */
-  static get f64(): BorshSchema {
+  static get f64(): BorshSchema<F64> {
     return BorshSchema.fromSchema('f64');
   }
 
@@ -142,7 +142,7 @@ export class BorshSchema {
    * const b: boolean = true;
    * const buffer = borshSerialize(BorshSchema.bool, b);
    */
-  static get bool(): BorshSchema {
+  static get bool(): BorshSchema<Bool> {
     return BorshSchema.fromSchema('bool');
   }
 
@@ -152,7 +152,7 @@ export class BorshSchema {
    * const message: string = 'hello world';
    * const buffer = borshSerialize(BorshSchema.String, message);
    */
-  static get String(): BorshSchema {
+  static get String(): BorshSchema<StringBSE> {
     return BorshSchema.fromSchema('string');
   }
 
@@ -167,8 +167,8 @@ export class BorshSchema {
    * const none: string | null = null;
    * const noneBuffer = borshSerialize(schema, none);
    */
-  static Option(value: BorshSchema): BorshSchema {
-    return BorshSchema.fromSchema({ option: value.toSchema() });
+  static Option<T extends BorshSchema<BSE>>(value: T): BorshSchema<Option<BSEType<T>>> {
+    return BorshSchema.fromSchema({ option: value.toSchema() } as Option<T>);
   }
 
   /**
@@ -178,8 +178,8 @@ export class BorshSchema {
    * const messages: string[] = ['hello', 'world'];
    * const buffer = borshSerialize(schema, messages);
    */
-  static Array(value: BorshSchema, length: number): BorshSchema {
-    return BorshSchema.fromSchema({ array: { type: value.toSchema(), len: length } });
+  static Array<T extends BorshSchema<BSE>>(value: T, length: number): BorshSchema<ArrayBSE<BSEType<T>>> {
+    return BorshSchema.fromSchema({ array: { type: value.toSchema(), len: length } } as ArrayBSE<T>);
   }
 
   /**
@@ -189,8 +189,8 @@ export class BorshSchema {
    * const messages: string[] = ['hello', 'world'];
    * const buffer = borshSerialize(schema, messages);
    */
-  static Vec(value: BorshSchema): BorshSchema {
-    return BorshSchema.fromSchema({ array: { type: value.toSchema() } });
+  static Vec<T extends BorshSchema<BSE>>(value: T): BorshSchema<Vec<BSEType<T>>> {
+    return BorshSchema.fromSchema({ array: { type: value.toSchema() } } as Vec<T>);
   }
 
   /**
@@ -200,8 +200,8 @@ export class BorshSchema {
    * const messages: Set<string> = new Set(['hello', 'world']);
    * const buffer = borshSerialize(schema, messages);
    */
-  static HashSet(value: BorshSchema): BorshSchema {
-    return BorshSchema.fromSchema({ set: value.toSchema() });
+  static HashSet<T extends BorshSchema<BSE>>(value: T): BorshSchema<HashSet<BSEType<T>>> {
+    return BorshSchema.fromSchema({ set: value.toSchema() } as HashSet<T>);
   }
 
   /**
@@ -214,8 +214,11 @@ export class BorshSchema {
    * ]);
    * const buffer = borshSerialize(schema, balances);
    */
-  static HashMap(key: BorshSchema, value: BorshSchema): BorshSchema {
-    return BorshSchema.fromSchema({ map: { key: key.toSchema(), value: value.toSchema() } });
+  static HashMap<K extends BorshSchema<BSE>, V extends BorshSchema<BSE>>(
+    key: K,
+    value: V,
+  ): BorshSchema<HashMap<BSEType<K>, BSEType<V>>> {
+    return BorshSchema.fromSchema({ map: { key: key.toSchema(), value: value.toSchema() } } as HashMap<K, V>);
   }
 
   /**
@@ -224,7 +227,7 @@ export class BorshSchema {
    * const unit: Unit = {};
    * const buffer = borshSerialize(BorshSchema.Unit, unit);
    */
-  static get Unit(): BorshSchema {
+  static get Unit(): BorshSchema<Struct<Unit>> {
     return BorshSchema.Struct({});
   }
 
@@ -248,8 +251,8 @@ export class BorshSchema {
    *
    * const buffer = borshSerialize(schema, person);
    */
-  static Struct(fields: StructFields): BorshSchema {
-    return BorshSchema.fromSchema({ struct: toStructTypeStruct(fields) });
+  static Struct<R extends Record<string, BorshSchema<BSE>>>(fields: R): BorshSchema<StructOf<R>> {
+    return BorshSchema.fromSchema({ struct: toStructTypeStruct(fields) } as Struct<R>);
   }
 
   /**
@@ -312,22 +315,130 @@ export class BorshSchema {
    *
    * const buffer = borshSerialize(schema, shape);
    */
-  static Enum(variants: EnumVariants): BorshSchema {
-    return BorshSchema.fromSchema({ enum: toEnumTypeEnum(variants) });
+  static Enum<R extends Record<string, BorshSchema<BSE>>>(variants: R): BorshSchema<EnumOf<R>> {
+    return BorshSchema.fromSchema({ enum: toEnumTypeEnum(variants) } as Enum<R>);
   }
 }
 
-function toStructTypeStruct(fields: StructFields): StructType['struct'] {
+function toStructTypeStruct<R extends Record<string, BorshSchema<BSE>>>(fields: R): StructType['struct'] {
   const entries = Object.entries(fields).map<[string, Schema]>(([key, value]) => [key, value.toSchema()]);
   return Object.fromEntries(entries);
 }
 
-function toEnumTypeEnum(variants: EnumVariants): EnumType['enum'] {
+function toEnumTypeEnum<R extends Record<string, BorshSchema<BSE>>>(variants: R): EnumType['enum'] {
   return Object.entries(variants).map<StructType>(([key, value]) => ({ struct: { [key]: value.toSchema() } }));
 }
 
 export type Unit = Record<string, never>;
 
-export type StructFields = Record<string, BorshSchema>;
+// "BorschSchemaElement"
+export type BSE =
+  | U8
+  | U16
+  | U32
+  | U64
+  | U128
+  | I8
+  | I16
+  | I32
+  | I64
+  | I128
+  | F32
+  | F64
+  | Bool
+  | StringBSE
+  | Option<unknown>
+  | ArrayBSE<unknown>
+  | Vec<unknown>
+  | HashSet<unknown>
+  | HashMap<unknown, unknown>
+  | Struct<Record<string, unknown>>
+  | Enum<Record<string, unknown>>;
 
-export type EnumVariants = Record<string, BorshSchema>;
+export type TypeOf<S extends BSE> = S extends U8
+  ? number
+  : S extends U16
+    ? number
+    : S extends U32
+      ? number
+      : S extends U64
+        ? bigint
+        : S extends U128
+          ? bigint
+          : S extends I8
+            ? number
+            : S extends I16
+              ? number
+              : S extends I32
+                ? number
+                : S extends I64
+                  ? bigint
+                  : S extends I128
+                    ? bigint
+                    : S extends F32
+                      ? number
+                      : S extends F64
+                        ? number
+                        : S extends Bool
+                          ? boolean
+                          : S extends string
+                            ? string
+                            : S extends Option<infer T>
+                              ? (T extends BSE ? TypeOf<T> : never) | null
+                              : S extends Array<infer T>
+                                ? (T extends BSE ? TypeOf<T> : never)[]
+                                : S extends Vec<infer T>
+                                  ? (T extends BSE ? TypeOf<T> : never)[]
+                                  : S extends HashSet<infer T>
+                                    ? Set<T extends BSE ? TypeOf<T> : never>
+                                    : S extends HashMap<infer K, infer V>
+                                      ? K extends BSE
+                                        ? V extends BSE
+                                          ? Map<TypeOf<K>, TypeOf<V>>
+                                          : never
+                                        : never
+                                      : S extends Struct<infer R>
+                                        ? R extends Record<string, BSE>
+                                          ? {
+                                              [K in keyof R]: TypeOf<R[K]>;
+                                            }
+                                          : never
+                                        : S extends Enum<infer R>
+                                          ? R extends Record<string, BSE>
+                                            ? { [K in keyof R]: { [KK in K]: TypeOf<R[K]> } }[keyof R]
+                                            : never
+                                          : never;
+
+type Brand<B, K> = K & { __brand: B };
+
+export type U8 = 'u8';
+export type U16 = 'u16';
+export type U32 = 'u32';
+export type U64 = 'u64';
+export type U128 = 'u128';
+export type I8 = 'i8';
+export type I16 = 'i16';
+export type I32 = 'i32';
+export type I64 = 'i64';
+export type I128 = 'i128';
+export type F32 = 'f32';
+export type F64 = 'f64';
+export type Bool = BoolType;
+export type StringBSE = StringType;
+export type Option<T> = Brand<T, OptionType>;
+export type ArrayBSE<T> = Brand<T, Readonly<{ array: { type: Schema; len: number } }>>;
+export type Vec<T> = Brand<T, Readonly<{ array: { type: Schema } }>>;
+export type HashSet<T> = Brand<T, SetType>;
+export type HashMap<K, V> = Brand<[K, V], MapType>;
+export type Struct<R extends Record<string, unknown>> = Brand<R, StructType>;
+export type Enum<R extends Record<string, unknown>> = Brand<R, EnumType>;
+
+type BSEType<T extends BorshSchema<BSE>> = T extends BorshSchema<infer S> ? S : never;
+
+type StructOf<R extends Record<string, BorshSchema<BSE>>> = Struct<{
+  [K in keyof R]: BSEType<R[K]>;
+}>;
+
+type EnumOf<R extends Record<string, BorshSchema<BSE>>> = Enum<{
+  [K in keyof R]: BSEType<R[K]>;
+}>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Buffer } from 'buffer';
-import { BorshSchema, EnumVariants, StructFields, Unit } from './BorshSchema';
+import { BSE, BorshSchema, TypeOf, Unit } from './BorshSchema';
 import { serialize, deserialize } from 'borsh';
 
-function borshSerialize<T>(schema: BorshSchema, data: T): Buffer {
+function borshSerialize<S extends BSE>(schema: BorshSchema<S>, data: TypeOf<S>): Buffer {
   return Buffer.from(serialize(schema.toSchema(), data));
 }
 
-function borshDeserialize<T>(schema: BorshSchema, buffer: Uint8Array): T {
-  return deserialize(schema.toSchema(), buffer) as T;
+function borshDeserialize<S extends BSE>(schema: BorshSchema<S>, buffer: Uint8Array): TypeOf<S> {
+  return deserialize(schema.toSchema(), buffer) as TypeOf<S>;
 }
 
-export { borshSerialize, borshDeserialize, BorshSchema, EnumVariants, StructFields, Unit };
+export { borshSerialize, borshDeserialize, BorshSchema, Unit };


### PR DESCRIPTION
* Closes #3 

> [!NOTE]  
> This will require a major version bump, as it removes + changes some exported types.

This change improves the `BorshSchema` helper by adding type annotations.

Typings are used in such a way that the parsed types are tied to the schemas, allowing TypeScript to fully infer the types of parsed data.
